### PR TITLE
Add _stringify wrapper function to fix encoding of single quote marks

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -28,10 +28,11 @@ OO._.extend(OoyalaApiClient.prototype, {
   },
 
   get: function(headers, apiPath, params, statusCb, dataCb, errCb, context) {
-    this._curl('GET', headers, apiPath, params, null, statusCb, dataCb, errCb, context)
+    this._curl('GET', headers, apiPath, params, null, statusCb, dataCb, errCb, context);
   },
+
   patch: function(headers, apiPath, params, body, statusCb, dataCb, errCb, context) {
-    this._curl('PATCH', headers, apiPath, params, body, statusCb, dataCb, errCb, context)
+    this._curl('PATCH', headers, apiPath, params, body, statusCb, dataCb, errCb, context);
   },
 
 
@@ -47,15 +48,13 @@ OO._.extend(OoyalaApiClient.prototype, {
     });
 
     params["signature"] = this._sign(params, method, apiPath, body).slice(0,43);
-    console.log('params',params)
     var options = {
              host: this.hostName,
              port: this.hostPort,
-             path: apiPath + "?" + querystring.stringify(params),
+             path: apiPath + "?" + this._stringify(params),
              headers: headers,
              method: method
     };
-    console.log('options',options)
     var data = '';
     var ci = 0;
     var req = httpClient.request(options, function(res) {
@@ -91,6 +90,12 @@ OO._.extend(OoyalaApiClient.prototype, {
     result.push(body || '');
     shasum.update(result.join(''));
     return shasum.digest('base64');
+  },
+
+  _stringify: function(param) {
+    // Fix the encoding of single quote marks, which querystring.stringify
+    // escapes with a slash.
+    return querystring.stringify(param).replace(/'|\\'/g, "%27");
   },
 
   __place_holder: false


### PR DESCRIPTION
The querystring.stringify function incorrectly encodes single quote marks, which are required for some Ooyala Query API commands.

This commit adds a wrapper function that fixes the encoding of single quote marks.
